### PR TITLE
added support for auto_parse option, which currently supports numbers only

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,10 +23,11 @@ Options may include:
 *   `trim`          If true, ignore whitespace immediately around the delimiter, defaults to false.
 *   `ltrim`         If true, ignore whitespace immediately following the delimiter (i.e. left-trim all fields), defaults to false.
 *   `rtrim`         If true, ignore whitespace immediately preceding the delimiter (i.e. right-trim all fields), defaults to false.
+*   `auto_parse`    If true, the parser will attempt to convert read data types to native types
  */
 
 Parser = function(options) {
-  var _base, _base1, _base2, _base3, _base4, _base5, _base6, _base7, _base8, _base9;
+  var _base, _base1, _base10, _base2, _base3, _base4, _base5, _base6, _base7, _base8, _base9;
   if (options == null) {
     options = {};
   }
@@ -63,6 +64,9 @@ Parser = function(options) {
   if ((_base9 = this.options).rtrim == null) {
     _base9.rtrim = false;
   }
+  if ((_base10 = this.options).auto_parse == null) {
+    _base10.auto_parse = false;
+  }
   this.lines = 0;
   this.buf = '';
   this.quoting = false;
@@ -73,6 +77,7 @@ Parser = function(options) {
   this.closingQuote = 0;
   this.line = [];
   this.chunks = [];
+  this.floatRegexp = /^(\-|\+)?([0-9]+(\.[0-9]+)?|Infinity)$/;
   return this;
 };
 
@@ -227,7 +232,11 @@ Parser.prototype.__write = function(chars, end, callback) {
           this.field = this.field.trimRight();
         }
       }
-      this.line.push(this.field);
+      if (this.options.auto_parse && this.floatRegexp.test(this.field)) {
+        this.line.push(parseFloat(this.field));
+      } else {
+        this.line.push(this.field);
+      }
       this.closingQuote = 0;
       this.field = '';
       if (isRowDelimiter) {

--- a/test/write.coffee
+++ b/test/write.coffee
@@ -28,6 +28,33 @@ describe 'write', ->
       next()
     parser.end()
   
+  it 'should read numbers in property if auto_parse is specified', (next) ->
+    data = []
+    parser = parse({ auto_parse: true })
+    parser.write """
+    20322051544,1979,8.8017226E7,ABC,45,2000-01-01
+    28392898392,1974,8.8392926e7,DEF,23,2050-11-27
+    """
+    parser.on 'readable', ->
+      while(d = parser.read())
+        data.push d
+    parser.on 'error', (err) ->
+      next err
+    parser.on 'finish', ->
+      data.should.eql [
+        [20322051544, 1979, 8.8017226e7, 'ABC', 45, '2000-01-01']
+        [28392898392, 1974, 8.8392926e7, 'DEF', 23, '2050-11-27']
+      ]
+
+      (typeof data[0][0]).should.eql 'number'
+      (typeof data[0][1]).should.eql 'number'
+      (typeof data[0][4]).should.eql 'number'
+      (typeof data[1][0]).should.eql 'number'
+      (typeof data[1][1]).should.eql 'number'
+      (typeof data[1][4]).should.eql 'number'
+      next()
+    parser.end()
+
   it 'string randomly splited', (next) ->
     data = []
     parser = parse()


### PR DESCRIPTION
Added an auto_parse option to parser to allow the user to attempt to automatically parse certain values into native types. This currently only supports checking for number types.
