### PR TITLE
Allow user to pass in custom date parsing functionn

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,6 +144,16 @@ Parser = function(options) {
   if ((base11 = this.options).auto_parse_date == null) {
     base11.auto_parse_date = false;
   }
+  if (this.options.auto_parse_date === true) {
+    this.options.auto_parse_date = function(value) {
+      var m;
+      m = Date.parse(value);
+      if (!isNaN(m)) {
+        value = new Date(m);
+      }
+      return value;
+    };
+  }
   if ((base12 = this.options).relax == null) {
     base12.relax = false;
   }
@@ -323,7 +333,6 @@ Parser.prototype.__write = function(chars, end) {
   })(this);
   auto_parse = (function(_this) {
     return function(value) {
-      var m;
       if (!_this.options.auto_parse) {
         return value;
       }
@@ -332,10 +341,7 @@ Parser.prototype.__write = function(chars, end) {
       } else if (is_float(value)) {
         value = parseFloat(value);
       } else if (_this.options.auto_parse_date) {
-        m = Date.parse(value);
-        if (!isNaN(m)) {
-          value = new Date(m);
-        }
+        value = _this.options.auto_parse_date(value);
       }
       return value;
     };

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -100,6 +100,12 @@ Options are documented [here](http://csv.adaltas.com/parse/).
       @options.rtrim ?= false
       @options.auto_parse ?= false
       @options.auto_parse_date ?= false
+      if @options.auto_parse_date is true
+        @options.auto_parse_date = (value) ->
+          m = Date.parse(value)
+          if !isNaN(m)
+            value = new Date(m)
+          value
       @options.relax ?= false
       @options.relax_column_count ?= false
       @options.skip_empty_lines ?= false
@@ -248,8 +254,7 @@ Implementation of the [`stream.Transform` API][transform]
         else if is_float value
           value = parseFloat value
         else if @options.auto_parse_date
-          m = Date.parse value
-          value = new Date m unless isNaN m
+          value = @options.auto_parse_date(value)
         value
       ltrim = @options.trim or @options.ltrim
       rtrim = @options.trim or @options.rtrim


### PR DESCRIPTION
This changes the option `auto_parse_date` to also accept `function`.

ex:
```js
options = {
  ...,
  auto_parse_date: function(value) { return value+' 00:05:00'; } 
}
```

Alternatively we could add `auto_parse_custom` using a similar approach to this PR and keep `auto_parse_date` as is.

Thoughts?