### PR TITLE
Added missing type overload

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -10,6 +10,7 @@ import * as stream from "stream";
 export = parse;
 
 declare function parse(input: string, options?: parse.Options, callback?: parse.Callback): any;
+declare function parse(input: string, callback?: parse.Callback): any;
 declare function parse(options?: parse.Options, callback?: parse.Callback): any;
 declare function parse(callback?: parse.Callback): any;
 declare namespace parse {


### PR DESCRIPTION
Calling `parse` with parameters `(input: string, callback?: parse.Callback)` would otherwise yield to a type error