### PR TITLE
Fix bad variable name in a sample

### DIFF
--- a/samples/api.pipe.js
+++ b/samples/api.pipe.js
@@ -16,4 +16,4 @@ const transformer = transform(function(record, callback){
 }, {
   parallel: 5
 })
-input.pipe(parser).pipe(transformer).pipe(process.stdout)
+generator.pipe(parser).pipe(transformer).pipe(process.stdout)


### PR DESCRIPTION
The previous example doesn't run due to change 0a935dc14e4a3854dc5a4f3cd486ee602ae6ebd6.