### PR TITLE
tests: add test that fails if the column count varies on each row

### DIFF
--- a/test/info.uneven_columns.coffee
+++ b/test/info.uneven_columns.coffee
@@ -1,0 +1,22 @@
+
+parse = require '../lib'
+
+describe 'info uneven_columns', ->
+
+  it 'emit readable event', (next) ->
+    records = []
+    parser = parse()
+    parser.on 'readable', ->
+      while record = this.read()
+        records.push record
+    parser.write """
+    "ABC","DEF"
+    G,H,I,J
+    """
+    parser.on 'end', ->
+      records.should.eql [
+        [ 'ABC', 'DEF' ]
+        [ 'G', 'H', 'I', 'J' ]
+      ]
+      next()
+    parser.end()


### PR DESCRIPTION
I'm trying to parse a CSV file from [a public website](http://nemweb.com.au/Reports/Current/Predispatch_Reports/), however it fails with an error:
```
Debug: internal, implementation, error
    Error: Invalid Record Length: expect 10, got 24 on line 2
    at Parser.__error (/src/node_modules/csv-parse/lib/index.js:812:17)
    at Parser.__onRow (/src/node_modules/csv-parse/lib/index.js:575:30)
    at Parser.__parse (/src/node_modules/csv-parse/lib/index.js:483:40)
    at Parser._transform (/src/node_modules/csv-parse/lib/index.js:332:22)
    at Parser.Transform._read (_stream_transform.js:186:10)
...
```
The problem seems to be because the CSV has a different number of columns on each row.  Since the error comes up saying it's an internal implementation error (rather than a usage error), I figure I should report it as a bug.

This PR includes a failing test case that demonstrates the problem, in case it is useful.