### PR TITLE
Avoid mutating options.columns

### DIFF
--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -108,7 +108,7 @@ function (_Transform) {
       fnFirstLineToHeaders = options.columns;
       options.columns = true;
     } else if (Array.isArray(options.columns)) {
-      normalizeColumnsArray(options.columns);
+      options.columns = normalizeColumnsArray(options.columns);
     } else if (options.columns === undefined || options.columns === null || options.columns === false) {
       options.columns = false;
     } else {
@@ -848,9 +848,9 @@ function (_Transform) {
           return this.__error("Invalid Header Mapping: expect an array, got ".concat(JSON.stringify(headers)));
         }
 
-        normalizeColumnsArray(headers);
-        this.state.expectedRecordLength = headers.length;
-        this.options.columns = headers;
+        const normalizedHeaders = normalizeColumnsArray(headers);
+        this.state.expectedRecordLength = normalizedHeaders.length;
+        this.options.columns = normalizedHeaders;
 
         this.__resetRow();
 
@@ -1154,15 +1154,17 @@ var firstLineToHeadersDefault = function firstLineToHeadersDefault(record) {
 };
 
 var normalizeColumnsArray = function normalizeColumnsArray(columns) {
+  var normalizedColumns = [];
+
   for (var i = 0; i < columns.length; i++) {
     var column = columns[i];
 
     if (column === undefined || column === null || column === false) {
-      columns[i] = {
+      normalizedColumns[i] = {
         disabled: true
       };
     } else if (typeof column === 'string') {
-      columns[i] = {
+      normalizedColumns[i] = {
         name: column
       };
     } else if (isObject(column)) {
@@ -1170,9 +1172,11 @@ var normalizeColumnsArray = function normalizeColumnsArray(columns) {
         throw new Error("Invalid Option columns: property \"name\" is required at position ".concat(i));
       }
 
-      columns[i] = column;
+      normalizedColumns[i] = column;
     } else {
       throw new Error("Invalid Option columns: expect a string or an object, got ".concat(JSON.stringify(column), " at position ").concat(i));
     }
   }
+
+  return normalizedColumns;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ class Parser extends Transform {
       fnFirstLineToHeaders = options.columns
       options.columns = true
     }else if(Array.isArray(options.columns)){
-      normalizeColumnsArray(options.columns)
+      options.columns = normalizeColumnsArray(options.columns)
     }else if(options.columns === undefined || options.columns === null || options.columns === false){
       options.columns = false
     }else{
@@ -646,9 +646,9 @@ class Parser extends Transform {
       if(!Array.isArray(headers)){
         return this.__error(`Invalid Header Mapping: expect an array, got ${JSON.stringify(headers)}`)
       }
-      normalizeColumnsArray(headers)
-      this.state.expectedRecordLength = headers.length
-      this.options.columns = headers
+      const normalizedHeaders = normalizeColumnsArray(headers)
+      this.state.expectedRecordLength = normalizedHeaders.length
+      this.options.columns = normalizedHeaders
       this.__resetRow()
       return
     }catch(err){
@@ -886,19 +886,23 @@ const firstLineToHeadersDefault = function(record){
 }
 
 const normalizeColumnsArray = function(columns){
+  const normalizedColumns = [];
+
   for(let i=0; i< columns.length; i++){
     const column = columns[i]
     if(column === undefined || column === null || column === false){
-      columns[i] = { disabled: true }
+      normalizedColumns[i] = { disabled: true }
     }else if(typeof column === 'string'){
-      columns[i] = { name: column }
+      normalizedColumns[i] = { name: column }
     }else if(isObject(column)){
       if(typeof column.name !== 'string'){
         throw new Error(`Invalid Option columns: property "name" is required at position ${i}`)
       }
-      columns[i] = column
+      normalizedColumns[i] = column
     }else{
       throw new Error(`Invalid Option columns: expect a string or an object, got ${JSON.stringify(column)} at position ${i}`)
     }
   }
+
+  return normalizedColumns;
 }


### PR DESCRIPTION
With the current implementation, an array passed as `options.columns` gets mutated through `normalizeColumnsArray ` function.

```typescript
import * as csvParser from 'csv-parser';

const columns: string[] = ['foo', 'bar', 'baz'];
const parser = csvParser({ columns });

console.log(columns);
// [{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]
```

This kind of implicit mutation of the given argument should generally be avoided as it causes unexpected behaviors.

This pull request addresses the problem by returning newly-created array, instead of mutating the given one in-place.