### PR TITLE
fix: add buffer as allowed type for input

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,8 +6,8 @@ import * as stream from "stream";
 
 export = parse;
 
-declare function parse(input: string, options?: parse.Options, callback?: parse.Callback): parse.Parser;
-declare function parse(input: string, callback?: parse.Callback): parse.Parser;
+declare function parse(input: Buffer | string, options?: parse.Options, callback?: parse.Callback): parse.Parser;
+declare function parse(input: Buffer | string, callback?: parse.Callback): parse.Parser;
 declare function parse(options?: parse.Options, callback?: parse.Callback): parse.Parser;
 declare function parse(callback?: parse.Callback): parse.Parser;
 declare namespace parse {

--- a/lib/sync.d.ts
+++ b/lib/sync.d.ts
@@ -2,5 +2,5 @@ import * as csvParse from './index';
 
 export = parse;
 
-declare function parse(input: string, options?: csvParse.Options): any;
+declare function parse(input: Buffer | string, options?: csvParse.Options): any;
 declare namespace parse {}


### PR DESCRIPTION
The signature only permits strings, which are checked and converted to Buffers in `parse`. In fact, Buffers are actually of the main path of the code.