### PR TITLE
field.toString().trim()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -650,7 +650,7 @@ class Parser extends Transform {
       return this.__resetRow()
     }
     if(skip_lines_with_empty_values === true){
-      if(record.every( (field) => field.trim() === '' )){
+      if(record.every( (field) => field.toString().trim() === '' )){
         this.__resetRow()
         return
       }


### PR DESCRIPTION
fix error 

caused by: TypeError: field.trim is not a function