### PR TITLE
field.toString().trim()

### DIFF
--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -819,7 +819,7 @@ function (_Transform) {
 
       if (skip_lines_with_empty_values === true) {
         if (record.every(function (field) {
-          return field.trim() === '';
+          return field.toString().trim() === '';
         })) {
           this.__resetRow();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -650,7 +650,7 @@ class Parser extends Transform {
       return this.__resetRow()
     }
     if(skip_lines_with_empty_values === true){
-      if(record.every( (field) => field.trim() === '' )){
+      if(record.every( (field) => field.toString().trim() === '' )){
         this.__resetRow()
         return
       }


### PR DESCRIPTION
fix error 

caused by: TypeError: field.trim is not a function




error happens when field is number 