### PR TITLE
Replace third-party dependency for string padding

### DIFF
--- a/bench/async.iterator.js
+++ b/bench/async.iterator.js
@@ -5,7 +5,6 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const stream = require('stream')
-const pad = require('pad')
 const finished = util.promisify(stream.finished)
 const parse = require('..')
 const generate = require('csv-generate')
@@ -52,9 +51,9 @@ const print = function(results){
   console.log([
     '|',
     [
-      pad(' length ', 10 + 2),
-      pad(' nanoseconds ', 15 + 2),
-      pad(' throughput ', 15 + 2),
+      ' length '.padEnd(10 + 2),
+      ' nanoseconds '.padEnd(15 + 2),
+      ' throughput '.padEnd(15 + 2),
     ].join('|'),
     '|',
   ].join(''))

--- a/package.json
+++ b/package.json
@@ -83,8 +83,5 @@
   "types": [
     "./lib/index.d.ts",
     "./lib/sync.d.ts"
-  ],
-  "dependencies": {
-    "pad": "^3.2.0"
-  }
+  ]
 }


### PR DESCRIPTION
This gets rid of unnecessary dependencies: `#padEnd` is supported from Node v8 (see https://node.green), `.travis.yml` lists Node v10 as the oldest supported version.

Indeed, this means csv-parse no longer depends on any third-party packages, which would be pretty neat. Currently:
```
$ npm install csv-parse
+ csv-parse@4.6.5
added 5 packages from 37 contributors
```