### PR TITLE
Request/csverror typescript support

### DIFF
--- a/lib/es5/index.d.ts
+++ b/lib/es5/index.d.ts
@@ -209,4 +209,32 @@ declare namespace parse {
          */
         readonly invalid_field_length: number;
     }
+
+    class CsvError extends Error {
+        readonly code: CsvErrorCode;
+        [key: string]: any;
+    
+        constructor(code: CsvErrorCode, message: string | string[], ...contexts: any[]);
+    }
+    
+    type CsvErrorCode = 
+        'CSV_INVALID_OPTION_BOM'
+        | 'CSV_INVALID_OPTION_CAST'
+        | 'CSV_INVALID_OPTION_CAST_DATE'
+        | 'CSV_INVALID_OPTION_COLUMNS'
+        | 'CSV_INVALID_OPTION_COLUMNS_DUPLICATES_TO_ARRAY'
+        | 'CSV_INVALID_OPTION_COMMENT'
+        | 'CSV_INVALID_OPTION_DELIMITER'
+        | 'CSV_INVALID_OPTION_ON_RECORD'
+        | 'CSV_INVALID_CLOSING_QUOTE'
+        | 'INVALID_OPENING_QUOTE'
+        | 'CSV_INVALID_COLUMN_MAPPING'
+        | 'CSV_INVALID_ARGUMENT'
+        | 'CSV_INVALID_COLUMN_DEFINITION'
+        | 'CSV_MAX_RECORD_SIZE'
+        | 'CSV_NON_TRIMABLE_CHAR_AFTER_CLOSING_QUOTE'
+        | 'CSV_QUOTE_NOT_CLOSED'
+        | 'CSV_INCONSISTENT_RECORD_LENGTH'
+        | 'CSV_RECORD_DONT_MATCH_COLUMNS_LENGTH'
+        | 'CSV_OPTION_COLUMNS_MISSING_NAME'
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -224,4 +224,32 @@ declare namespace parse {
          */
         readonly invalid_field_length: number;
     }
+    
+    class CsvError extends Error {
+        readonly code: CsvErrorCode;
+        [key: string]: any;
+    
+        constructor(code: CsvErrorCode, message: string | string[], ...contexts: any[]);
+    }
+    
+    type CsvErrorCode = 
+        'CSV_INVALID_OPTION_BOM'
+        | 'CSV_INVALID_OPTION_CAST'
+        | 'CSV_INVALID_OPTION_CAST_DATE'
+        | 'CSV_INVALID_OPTION_COLUMNS'
+        | 'CSV_INVALID_OPTION_COLUMNS_DUPLICATES_TO_ARRAY'
+        | 'CSV_INVALID_OPTION_COMMENT'
+        | 'CSV_INVALID_OPTION_DELIMITER'
+        | 'CSV_INVALID_OPTION_ON_RECORD'
+        | 'CSV_INVALID_CLOSING_QUOTE'
+        | 'INVALID_OPENING_QUOTE'
+        | 'CSV_INVALID_COLUMN_MAPPING'
+        | 'CSV_INVALID_ARGUMENT'
+        | 'CSV_INVALID_COLUMN_DEFINITION'
+        | 'CSV_MAX_RECORD_SIZE'
+        | 'CSV_NON_TRIMABLE_CHAR_AFTER_CLOSING_QUOTE'
+        | 'CSV_QUOTE_NOT_CLOSED'
+        | 'CSV_INCONSISTENT_RECORD_LENGTH'
+        | 'CSV_RECORD_DONT_MATCH_COLUMNS_LENGTH'
+        | 'CSV_OPTION_COLUMNS_MISSING_NAME'
 }

--- a/test/api.types.ts
+++ b/test/api.types.ts
@@ -2,7 +2,7 @@
 import 'should'
 import * as parse from '../lib/index'
 import * as parse_sync from '../lib/sync'
-import {CastingContext, Info, Options, Parser} from '../lib/index'
+import {CastingContext, Info, Options, Parser, CsvError} from '../lib/index'
 
 describe('API Types', () => {
   
@@ -320,4 +320,37 @@ describe('API Types', () => {
     })
   })
   
+  describe('CsvError', () => {
+    describe('Typescript definition is accurate', () => {
+      it('Minimum', () => {
+        const error = new CsvError("CSV_INCONSISTENT_RECORD_LENGTH", "MESSAGE");
+        
+        error.code.should.eql("CSV_INCONSISTENT_RECORD_LENGTH")
+        error.message.should.eql("MESSAGE")
+      })
+
+      it('Multiple messages', () => {
+        const error = new CsvError("CSV_INCONSISTENT_RECORD_LENGTH", ["MESSAGE1", "MESSAGE2"])
+
+        error.code.should.eql("CSV_INCONSISTENT_RECORD_LENGTH")
+        error.message.should.eql("MESSAGE1 MESSAGE2")
+      })
+
+      it('Supports contexts', () => {
+        const error = new CsvError("CSV_INCONSISTENT_RECORD_LENGTH", "MESSAGE", { testContext: { testProp: "testValue" } })
+
+        error.code.should.eql("CSV_INCONSISTENT_RECORD_LENGTH")
+        error.message.should.eql("MESSAGE")
+        error.should.have.key("testContext").and.eql({ testProp: "testValue" })
+      })
+    })
+
+    it('Proper type is thrown when an error is encountered', () => {
+      parse(`a,b\nc`, function (e: Error) {
+        const isCsvError = e instanceof CsvError;
+        isCsvError.should.be.true();
+        (e as CsvError).code.should.eql('CSV_INCONSISTENT_RECORD_LENGTH');
+      })
+    })
+  })
 })


### PR DESCRIPTION
I've added a Typescript definition for `CsvError` to address issue #295.

I also added the `CsvErrorCode` type to enumerate the possible error messages. Definitely not required, just thought it would be nice. I can remove it if that's preferred. Also, let me know if there are other tests you'd like to see performed.