### PR TITLE
Allow `parse.Options.escape` to be null or false.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -102,7 +102,7 @@ declare namespace parse {
         /**
          * Set the escape character, one character only, defaults to double quotes.
          */
-        escape?: string | Buffer;
+        escape?: string | null | false | Buffer;
         /**
          * Start handling records from the requested number of records.
          */


### PR DESCRIPTION
The documentation specifies that you can set this value to `null` or `false` to disable escaping, but the types don't allow that.