### PR TITLE
Maintain leading zero numbers in arrays

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -786,7 +786,7 @@ class Parser extends Transform {
         ], this.options, this.__context(), {
           record: record,
         })
-      if(relax_column_count === true || 
+      if(relax_column_count === true ||
         (relax_column_count_less === true && recordLength < this.state.expectedRecordLength) ||
         (relax_column_count_more === true && recordLength > this.state.expectedRecordLength) ){
         this.info.invalid_field_length++
@@ -816,7 +816,7 @@ class Parser extends Transform {
         for(let i = 0, l = record.length; i < l; i++){
           if(columns[i] === undefined || columns[i].disabled) continue
           // Turn duplicate columns into an array
-          if (columns_duplicates_to_array === true && obj[columns[i].name]) {
+          if (columns_duplicates_to_array === true && (obj[columns[i].name] || obj[columns[i].name] === 0)) {
             if (Array.isArray(obj[columns[i].name])) {
               obj[columns[i].name] = obj[columns[i].name].concat(record[i])
             } else {

--- a/test/option.cast.coffee
+++ b/test/option.cast.coffee
@@ -3,21 +3,21 @@ parse = require '../lib'
 assert_error = require './api.assert_error'
 
 describe 'Option `cast`', ->
-  
+
   it 'validate', ->
     (->
       parse cast: 'ohno', ( -> )
     ).should.throw
       message: 'Invalid option cast: cast must be true or a function, got "ohno"'
       code: 'CSV_INVALID_OPTION_CAST'
-  
+
   describe 'boolean true', ->
-  
+
     it 'all columns', (next) ->
       parse '1,2,3', cast: true, (err, data) ->
         data.should.eql [ [1, 2, 3] ]
         next()
-    
+
     it 'convert numbers', (next) ->
       data = []
       parser = parse({ cast: true })
@@ -53,7 +53,7 @@ describe 'Option `cast`', ->
       parse '123a,1.23,0.123,01.23,.123,123.', cast: true, (err, data) ->
         data.should.eql [ ['123a', 1.23, 0.123, 1.23, 0.123, 123] ]
         next()
-    
+
   describe 'function', ->
 
     it 'custom function', (next) ->
@@ -126,7 +126,7 @@ describe 'Option `cast`', ->
           [ false, true ]
         ] unless err
         next err
-      
+
       it 'return undefined', ->
 
     it 'accept all values', (next) ->
@@ -146,7 +146,7 @@ describe 'Option `cast`', ->
       , (err, records) ->
         records.shift().should.eql [undefined, false, null]
         next err
-    
+
   describe 'columns', ->
 
     it 'header is true on first line when columns is true', (next) ->
@@ -234,8 +234,27 @@ describe 'Option `cast`', ->
           code: 'CSV_INVALID_COLUMN_DEFINITION'
         next()
 
+  describe 'columns_duplicates_to_array', ->
+
+    it 'leading zeros are maintained when columns_duplicates_to_array is true', (next) ->
+      parse """
+      FIELD_1,FIELD_1,FIELD_1
+      0,2,3
+      0,0,4
+      """,
+        cast: true
+        columns: true
+        columns_duplicates_to_array: true
+      , (err, data) ->
+        data.should.eql [
+          'FIELD_1': [0, 2, 3]
+        ,
+          'FIELD_1': [0, 0, 4]
+        ] unless err
+        next err
+
   describe 'error', ->
-    
+
     it 'catch error', (next) ->
       parse """
       1,2,3


### PR DESCRIPTION
We noticed that combining
- `cast: true`
- `columns_duplicates_to_array: true`
- and data sets beginning with zero(s)

would  cause the leading zeros to be skipped (over-written by subsequent non-zeros).

This solution doesn't cover other falsy values, but we would very much appreciate any solution that includes leading zeros in arrays of numbers.

Thanks so much.