### PR TITLE
Refactor: rename skip_lines_with_empty_values to skip_records_with_empty_values

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -120,7 +120,7 @@ function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArra
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (_i = _i.call(arr), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
@@ -130,7 +130,7 @@ function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread n
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 
@@ -158,7 +158,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -514,14 +514,14 @@ var Parser = /*#__PURE__*/function (_Transform) {
         options.skip_empty_lines = false;
       } else {
         throw new Error("Invalid Option: skip_empty_lines must be a boolean, got ".concat(JSON.stringify(options.skip_empty_lines)));
-      } // Normalize option `skip_lines_with_empty_values`
+      } // Normalize option `skip_records_with_empty_values`
 
 
-      if (typeof options.skip_lines_with_empty_values === 'boolean') {// Great, nothing to do
-      } else if (options.skip_lines_with_empty_values === undefined || options.skip_lines_with_empty_values === null) {
-        options.skip_lines_with_empty_values = false;
+      if (typeof options.skip_records_with_empty_values === 'boolean') {// Great, nothing to do
+      } else if (options.skip_records_with_empty_values === undefined || options.skip_records_with_empty_values === null) {
+        options.skip_records_with_empty_values = false;
       } else {
-        throw new Error("Invalid Option: skip_lines_with_empty_values must be a boolean, got ".concat(JSON.stringify(options.skip_lines_with_empty_values)));
+        throw new Error("Invalid Option: skip_records_with_empty_values must be a boolean, got ".concat(JSON.stringify(options.skip_records_with_empty_values)));
       } // Normalize option `skip_lines_with_error`
 
 
@@ -994,7 +994,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
           relax_column_count_less = _this$options2.relax_column_count_less,
           relax_column_count_more = _this$options2.relax_column_count_more,
           raw = _this$options2.raw,
-          skip_lines_with_empty_values = _this$options2.skip_lines_with_empty_values;
+          skip_records_with_empty_values = _this$options2.skip_records_with_empty_values;
       var _this$state2 = this.state,
           enabled = _this$state2.enabled,
           record = _this$state2.record;
@@ -1042,7 +1042,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
         }
       }
 
-      if (skip_lines_with_empty_values === true) {
+      if (skip_records_with_empty_values === true) {
         if (isRecordEmpty(record)) {
           this.__resetRecord();
 
@@ -4004,31 +4004,52 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise(function (resolve, reject) {
-    function eventListener() {
-      if (errorListener !== undefined) {
+    function errorListener(err) {
+      emitter.removeListener(name, resolver);
+      reject(err);
+    }
+
+    function resolver() {
+      if (typeof emitter.removeListener === 'function') {
         emitter.removeListener('error', errorListener);
       }
       resolve([].slice.call(arguments));
     };
-    var errorListener;
 
-    // Adding an error listener is not optional because
-    // if an error is thrown on an event emitter we cannot
-    // guarantee that the actual event we are waiting will
-    // be fired. The result could be a silent way to create
-    // memory or file descriptor leaks, which is something
-    // we should avoid.
+    eventTargetAgnosticAddListener(emitter, name, resolver, { once: true });
     if (name !== 'error') {
-      errorListener = function errorListener(err) {
-        emitter.removeListener(name, eventListener);
-        reject(err);
-      };
-
-      emitter.once('error', errorListener);
+      addErrorHandlerIfEventEmitter(emitter, errorListener, { once: true });
     }
-
-    emitter.once(name, eventListener);
   });
+}
+
+function addErrorHandlerIfEventEmitter(emitter, handler, flags) {
+  if (typeof emitter.on === 'function') {
+    eventTargetAgnosticAddListener(emitter, 'error', handler, flags);
+  }
+}
+
+function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
+  if (typeof emitter.on === 'function') {
+    if (flags.once) {
+      emitter.once(name, listener);
+    } else {
+      emitter.on(name, listener);
+    }
+  } else if (typeof emitter.addEventListener === 'function') {
+    // EventTarget does not have `error` event semantics like Node
+    // EventEmitters, we do not listen for `error` events here.
+    emitter.addEventListener(name, function wrapListener(arg) {
+      // IE does not have builtin `{ once: true }` support so we
+      // have to do it manually.
+      if (flags.once) {
+        emitter.removeEventListener(name, wrapListener);
+      }
+      listener(arg);
+    });
+  } else {
+    throw new TypeError('The "emitter" argument must be of type EventEmitter. Received type ' + typeof emitter);
+  }
 }
 
 },{}],7:[function(require,module,exports){

--- a/lib/browser/sync.js
+++ b/lib/browser/sync.js
@@ -120,7 +120,7 @@ function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArra
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (_i = _i.call(arr), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
@@ -130,7 +130,7 @@ function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread n
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 
@@ -158,7 +158,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -514,14 +514,14 @@ var Parser = /*#__PURE__*/function (_Transform) {
         options.skip_empty_lines = false;
       } else {
         throw new Error("Invalid Option: skip_empty_lines must be a boolean, got ".concat(JSON.stringify(options.skip_empty_lines)));
-      } // Normalize option `skip_lines_with_empty_values`
+      } // Normalize option `skip_records_with_empty_values`
 
 
-      if (typeof options.skip_lines_with_empty_values === 'boolean') {// Great, nothing to do
-      } else if (options.skip_lines_with_empty_values === undefined || options.skip_lines_with_empty_values === null) {
-        options.skip_lines_with_empty_values = false;
+      if (typeof options.skip_records_with_empty_values === 'boolean') {// Great, nothing to do
+      } else if (options.skip_records_with_empty_values === undefined || options.skip_records_with_empty_values === null) {
+        options.skip_records_with_empty_values = false;
       } else {
-        throw new Error("Invalid Option: skip_lines_with_empty_values must be a boolean, got ".concat(JSON.stringify(options.skip_lines_with_empty_values)));
+        throw new Error("Invalid Option: skip_records_with_empty_values must be a boolean, got ".concat(JSON.stringify(options.skip_records_with_empty_values)));
       } // Normalize option `skip_lines_with_error`
 
 
@@ -994,7 +994,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
           relax_column_count_less = _this$options2.relax_column_count_less,
           relax_column_count_more = _this$options2.relax_column_count_more,
           raw = _this$options2.raw,
-          skip_lines_with_empty_values = _this$options2.skip_lines_with_empty_values;
+          skip_records_with_empty_values = _this$options2.skip_records_with_empty_values;
       var _this$state2 = this.state,
           enabled = _this$state2.enabled,
           record = _this$state2.record;
@@ -1042,7 +1042,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
         }
       }
 
-      if (skip_lines_with_empty_values === true) {
+      if (skip_records_with_empty_values === true) {
         if (isRecordEmpty(record)) {
           this.__resetRecord();
 
@@ -4041,31 +4041,52 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise(function (resolve, reject) {
-    function eventListener() {
-      if (errorListener !== undefined) {
+    function errorListener(err) {
+      emitter.removeListener(name, resolver);
+      reject(err);
+    }
+
+    function resolver() {
+      if (typeof emitter.removeListener === 'function') {
         emitter.removeListener('error', errorListener);
       }
       resolve([].slice.call(arguments));
     };
-    var errorListener;
 
-    // Adding an error listener is not optional because
-    // if an error is thrown on an event emitter we cannot
-    // guarantee that the actual event we are waiting will
-    // be fired. The result could be a silent way to create
-    // memory or file descriptor leaks, which is something
-    // we should avoid.
+    eventTargetAgnosticAddListener(emitter, name, resolver, { once: true });
     if (name !== 'error') {
-      errorListener = function errorListener(err) {
-        emitter.removeListener(name, eventListener);
-        reject(err);
-      };
-
-      emitter.once('error', errorListener);
+      addErrorHandlerIfEventEmitter(emitter, errorListener, { once: true });
     }
-
-    emitter.once(name, eventListener);
   });
+}
+
+function addErrorHandlerIfEventEmitter(emitter, handler, flags) {
+  if (typeof emitter.on === 'function') {
+    eventTargetAgnosticAddListener(emitter, 'error', handler, flags);
+  }
+}
+
+function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
+  if (typeof emitter.on === 'function') {
+    if (flags.once) {
+      emitter.once(name, listener);
+    } else {
+      emitter.on(name, listener);
+    }
+  } else if (typeof emitter.addEventListener === 'function') {
+    // EventTarget does not have `error` event semantics like Node
+    // EventEmitters, we do not listen for `error` events here.
+    emitter.addEventListener(name, function wrapListener(arg) {
+      // IE does not have builtin `{ once: true }` support so we
+      // have to do it manually.
+      if (flags.once) {
+        emitter.removeEventListener(name, wrapListener);
+      }
+      listener(arg);
+    });
+  } else {
+    throw new TypeError('The "emitter" argument must be of type EventEmitter. Received type ' + typeof emitter);
+  }
 }
 
 },{}],8:[function(require,module,exports){

--- a/lib/es5/index.d.ts
+++ b/lib/es5/index.d.ts
@@ -193,8 +193,8 @@ declare namespace parse {
         /**
          * Don't generate records for lines containing empty column values (column matching /\s*\/), defaults to false.
          */
-        skip_lines_with_empty_values?: boolean;
-        skipLinesWithEmptyValues?: boolean;
+        skip_records_with_empty_values?: boolean;
+        skipRecordsWithEmptyValues?: boolean;
         /**
          * Stop handling records after the requested number of records.
          */

--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -12,7 +12,7 @@ function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArra
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (_i = _i.call(arr), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
@@ -22,7 +22,7 @@ function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread n
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 
@@ -50,7 +50,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -406,14 +406,14 @@ var Parser = /*#__PURE__*/function (_Transform) {
         options.skip_empty_lines = false;
       } else {
         throw new Error("Invalid Option: skip_empty_lines must be a boolean, got ".concat(JSON.stringify(options.skip_empty_lines)));
-      } // Normalize option `skip_lines_with_empty_values`
+      } // Normalize option `skip_records_with_empty_values`
 
 
-      if (typeof options.skip_lines_with_empty_values === 'boolean') {// Great, nothing to do
-      } else if (options.skip_lines_with_empty_values === undefined || options.skip_lines_with_empty_values === null) {
-        options.skip_lines_with_empty_values = false;
+      if (typeof options.skip_records_with_empty_values === 'boolean') {// Great, nothing to do
+      } else if (options.skip_records_with_empty_values === undefined || options.skip_records_with_empty_values === null) {
+        options.skip_records_with_empty_values = false;
       } else {
-        throw new Error("Invalid Option: skip_lines_with_empty_values must be a boolean, got ".concat(JSON.stringify(options.skip_lines_with_empty_values)));
+        throw new Error("Invalid Option: skip_records_with_empty_values must be a boolean, got ".concat(JSON.stringify(options.skip_records_with_empty_values)));
       } // Normalize option `skip_lines_with_error`
 
 
@@ -886,7 +886,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
           relax_column_count_less = _this$options2.relax_column_count_less,
           relax_column_count_more = _this$options2.relax_column_count_more,
           raw = _this$options2.raw,
-          skip_lines_with_empty_values = _this$options2.skip_lines_with_empty_values;
+          skip_records_with_empty_values = _this$options2.skip_records_with_empty_values;
       var _this$state2 = this.state,
           enabled = _this$state2.enabled,
           record = _this$state2.record;
@@ -934,7 +934,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
         }
       }
 
-      if (skip_lines_with_empty_values === true) {
+      if (skip_records_with_empty_values === true) {
         if (isRecordEmpty(record)) {
           this.__resetRecord();
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -193,8 +193,8 @@ declare namespace parse {
         /**
          * Don't generate records for lines containing empty column values (column matching /\s*\/), defaults to false.
          */
-        skip_lines_with_empty_values?: boolean;
-        skipLinesWithEmptyValues?: boolean;
+        skip_records_with_empty_values?: boolean;
+        skipRecordsWithEmptyValues?: boolean;
         /**
          * Stop handling records after the requested number of records.
          */

--- a/lib/index.js
+++ b/lib/index.js
@@ -341,13 +341,13 @@ class Parser extends Transform {
     }else{
       throw new Error(`Invalid Option: skip_empty_lines must be a boolean, got ${JSON.stringify(options.skip_empty_lines)}`)
     }
-    // Normalize option `skip_lines_with_empty_values`
-    if(typeof options.skip_lines_with_empty_values === 'boolean'){
+    // Normalize option `skip_records_with_empty_values`
+    if(typeof options.skip_records_with_empty_values === 'boolean'){
       // Great, nothing to do
-    }else if(options.skip_lines_with_empty_values === undefined || options.skip_lines_with_empty_values === null){
-      options.skip_lines_with_empty_values = false
+    }else if(options.skip_records_with_empty_values === undefined || options.skip_records_with_empty_values === null){
+      options.skip_records_with_empty_values = false
     }else{
-      throw new Error(`Invalid Option: skip_lines_with_empty_values must be a boolean, got ${JSON.stringify(options.skip_lines_with_empty_values)}`)
+      throw new Error(`Invalid Option: skip_records_with_empty_values must be a boolean, got ${JSON.stringify(options.skip_records_with_empty_values)}`)
     }
     // Normalize option `skip_lines_with_error`
     if(typeof options.skip_lines_with_error === 'boolean'){
@@ -748,7 +748,7 @@ class Parser extends Transform {
     }
   }
   __onRecord(){
-    const {columns, columns_duplicates_to_array, encoding, info, from, relax_column_count, relax_column_count_less, relax_column_count_more, raw, skip_lines_with_empty_values} = this.options
+    const {columns, columns_duplicates_to_array, encoding, info, from, relax_column_count, relax_column_count_less, relax_column_count_more, raw, skip_records_with_empty_values} = this.options
     const {enabled, record} = this.state
     if(enabled === false){
       return this.__resetRecord()
@@ -797,7 +797,7 @@ class Parser extends Transform {
         if(finalErr) return finalErr
       }
     }
-    if(skip_lines_with_empty_values === true){
+    if(skip_records_with_empty_values === true){
       if(isRecordEmpty(record)){
         this.__resetRecord()
         return

--- a/test/api.types.ts
+++ b/test/api.types.ts
@@ -35,7 +35,7 @@ describe('API Types', () => {
         'on_record', 'quote', 'raw', 'record_delimiter', 'relax',
         'relax_column_count', 'relax_column_count_less',
         'relax_column_count_more', 'rtrim', 'skip_empty_lines',
-        'skip_lines_with_empty_values', 'skip_lines_with_error', 'to',
+        'skip_lines_with_error', 'skip_records_with_empty_values', 'to',
         'to_line', 'trim'
       ])
     })
@@ -277,10 +277,10 @@ describe('API Types', () => {
       options.skipEmptyLines = true
     })
     
-    it('skip_lines_with_empty_values', () => {
+    it('skip_records_with_empty_values', () => {
       const options: Options = {}
-      options.skip_lines_with_empty_values = true
-      options.skipLinesWithEmptyValues = true
+      options.skip_records_with_empty_values = true
+      options.skipRecordsWithEmptyValues = true
     })
     
     it('skip_lines_with_error', () => {

--- a/test/option.columns.coffee
+++ b/test/option.columns.coffee
@@ -98,12 +98,12 @@ describe 'Option `columns`', ->
         ] unless err
         next err
 
-    it 'header detection honors skip_lines_with_empty_values', (next) ->
+    it 'header detection honors skip_records_with_empty_values', (next) ->
       parse """
       ,,
       a,b,c
       1,2,3
-      """, columns: true, skip_lines_with_empty_values: true, (err, data) ->
+      """, columns: true, skip_records_with_empty_values: true, (err, data) ->
         data.should.eql [
           {a: "1", b: "2", c: "3"}
         ] unless err

--- a/test/option.skip_lines_with_empty_values.coffee
+++ b/test/option.skip_lines_with_empty_values.coffee
@@ -1,19 +1,19 @@
 
 parse = require '../lib'
 
-describe 'Option `skip_lines_with_empty_values`', ->
+describe 'Option `skip_records_with_empty_values`', ->
   
   it 'validation', ->
-    parse '', skip_lines_with_empty_values: true, (->)
-    parse '', skip_lines_with_empty_values: false, (->)
-    parse '', skip_lines_with_empty_values: null, (->)
-    parse '', skip_lines_with_empty_values: undefined, (->)
+    parse '', skip_records_with_empty_values: true, (->)
+    parse '', skip_records_with_empty_values: false, (->)
+    parse '', skip_records_with_empty_values: null, (->)
+    parse '', skip_records_with_empty_values: undefined, (->)
     (->
-      parse '', skip_lines_with_empty_values: 1, (->)
-    ).should.throw 'Invalid Option: skip_lines_with_empty_values must be a boolean, got 1'
+      parse '', skip_records_with_empty_values: 1, (->)
+    ).should.throw 'Invalid Option: skip_records_with_empty_values must be a boolean, got 1'
     (->
-      parse '', skip_lines_with_empty_values: 'oh no', (->)
-    ).should.throw 'Invalid Option: skip_lines_with_empty_values must be a boolean, got "oh no"'
+      parse '', skip_records_with_empty_values: 'oh no', (->)
+    ).should.throw 'Invalid Option: skip_records_with_empty_values must be a boolean, got "oh no"'
   
   it 'dont skip by default', (next) ->
     parse """
@@ -35,7 +35,7 @@ describe 'Option `skip_lines_with_empty_values`', ->
     ,
     IJK,LMN
     ,
-    """, skip_lines_with_empty_values: true, (err, data) ->
+    """, skip_records_with_empty_values: true, (err, data) ->
       return next err if err
       data.should.eql [
         [ 'ABC', 'DEF' ]
@@ -49,7 +49,7 @@ describe 'Option `skip_lines_with_empty_values`', ->
     \t , \t
     IJK,LMN
     \t , \t
-    """, skip_lines_with_empty_values: true, (err, data) ->
+    """, skip_records_with_empty_values: true, (err, data) ->
       return next err if err
       data.should.eql [
         [ 'ABC', 'DEF' ]
@@ -65,7 +65,7 @@ describe 'Option `skip_lines_with_empty_values`', ->
     null
     undefined
     """,
-      skip_lines_with_empty_values: true
+      skip_records_with_empty_values: true
       cast: (value) ->
         switch value
           when 'empty_buffer' then Buffer.from ''


### PR DESCRIPTION
Hello

I would like to give back to a project that has been useful to me and I spotted the todo list. Starting at the top, is this what you are looking for for a future major release with breaking changes or do you want it to be backwards compatible?

Thanks!