### PR TITLE
feat: Add info.bytes property.

### DIFF
--- a/lib/browser/index.js
+++ b/lib/browser/index.js
@@ -120,7 +120,7 @@ function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArra
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
@@ -130,13 +130,13 @@ function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread n
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
@@ -158,7 +158,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -612,6 +612,8 @@ var Parser = /*#__PURE__*/function (_Transform) {
       this.options = options;
       this.state = {
         bomSkipped: false,
+        bufBytesPos: 0,
+        bufBytesStart: 0,
         castField: fnCastField,
         commenting: false,
         // Current error encountered by a record
@@ -727,7 +729,9 @@ var Parser = /*#__PURE__*/function (_Transform) {
           for (var encoding in boms) {
             if (boms[encoding].compare(buf, 0, boms[encoding].length) === 0) {
               // Skip BOM
-              buf = buf.slice(boms[encoding].length); // Renormalize original options with the new encoding
+              var bomLength = boms[encoding].length;
+              this.state.bufBytesStart += bomLength;
+              buf = buf.slice(bomLength); // Renormalize original options with the new encoding
 
               this.__normalizeOptions(_objectSpread(_objectSpread({}, this.__originalOptions), {}, {
                 encoding: encoding
@@ -882,9 +886,12 @@ var Parser = /*#__PURE__*/function (_Transform) {
                   continue;
                 }
 
+                this.state.bufBytesPos = this.state.bufBytesStart + pos;
+
                 var errField = this.__onField();
 
                 if (errField !== undefined) return errField;
+                this.state.bufBytesPos = this.state.bufBytesStart + pos + recordDelimiterLength;
 
                 var errRecord = this.__onRecord();
 
@@ -916,6 +923,8 @@ var Parser = /*#__PURE__*/function (_Transform) {
             var delimiterLength = this.__isDelimiter(buf, pos, chr);
 
             if (delimiterLength !== 0) {
+              this.state.bufBytesPos = this.state.bufBytesStart + pos;
+
               var _errField = this.__onField();
 
               if (_errField !== undefined) return _errField;
@@ -955,6 +964,8 @@ var Parser = /*#__PURE__*/function (_Transform) {
         } else {
           // Skip last line if it has no characters
           if (this.state.wasQuoting === true || this.state.record.length !== 0 || this.state.field.length !== 0) {
+            this.state.bufBytesPos = pos;
+
             var _errField2 = this.__onField();
 
             if (_errField2 !== undefined) return _errField2;
@@ -969,6 +980,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
           }
         }
       } else {
+        this.state.bufBytesStart += pos;
         this.state.previousBuf = buf.slice(pos);
       }
 
@@ -1461,6 +1473,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
     value: function __infoRecord() {
       var columns = this.options.columns;
       return _objectSpread(_objectSpread({}, this.__infoDataSet()), {}, {
+        bytes: this.state.bufBytesStart + this.state.bufBytesPos,
         error: this.state.error,
         header: columns === true,
         index: this.state.record.length
@@ -4012,31 +4025,52 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise(function (resolve, reject) {
-    function eventListener() {
-      if (errorListener !== undefined) {
+    function errorListener(err) {
+      emitter.removeListener(name, resolver);
+      reject(err);
+    }
+
+    function resolver() {
+      if (typeof emitter.removeListener === 'function') {
         emitter.removeListener('error', errorListener);
       }
       resolve([].slice.call(arguments));
     };
-    var errorListener;
 
-    // Adding an error listener is not optional because
-    // if an error is thrown on an event emitter we cannot
-    // guarantee that the actual event we are waiting will
-    // be fired. The result could be a silent way to create
-    // memory or file descriptor leaks, which is something
-    // we should avoid.
+    eventTargetAgnosticAddListener(emitter, name, resolver, { once: true });
     if (name !== 'error') {
-      errorListener = function errorListener(err) {
-        emitter.removeListener(name, eventListener);
-        reject(err);
-      };
-
-      emitter.once('error', errorListener);
+      addErrorHandlerIfEventEmitter(emitter, errorListener, { once: true });
     }
-
-    emitter.once(name, eventListener);
   });
+}
+
+function addErrorHandlerIfEventEmitter(emitter, handler, flags) {
+  if (typeof emitter.on === 'function') {
+    eventTargetAgnosticAddListener(emitter, 'error', handler, flags);
+  }
+}
+
+function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
+  if (typeof emitter.on === 'function') {
+    if (flags.once) {
+      emitter.once(name, listener);
+    } else {
+      emitter.on(name, listener);
+    }
+  } else if (typeof emitter.addEventListener === 'function') {
+    // EventTarget does not have `error` event semantics like Node
+    // EventEmitters, we do not listen for `error` events here.
+    emitter.addEventListener(name, function wrapListener(arg) {
+      // IE does not have builtin `{ once: true }` support so we
+      // have to do it manually.
+      if (flags.once) {
+        emitter.removeEventListener(name, wrapListener);
+      }
+      listener(arg);
+    });
+  } else {
+    throw new TypeError('The "emitter" argument must be of type EventEmitter. Received type ' + typeof emitter);
+  }
 }
 
 },{}],7:[function(require,module,exports){

--- a/lib/browser/sync.js
+++ b/lib/browser/sync.js
@@ -120,7 +120,7 @@ function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArra
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
@@ -130,13 +130,13 @@ function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread n
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
@@ -158,7 +158,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -612,6 +612,8 @@ var Parser = /*#__PURE__*/function (_Transform) {
       this.options = options;
       this.state = {
         bomSkipped: false,
+        bufBytesPos: 0,
+        bufBytesStart: 0,
         castField: fnCastField,
         commenting: false,
         // Current error encountered by a record
@@ -727,7 +729,9 @@ var Parser = /*#__PURE__*/function (_Transform) {
           for (var encoding in boms) {
             if (boms[encoding].compare(buf, 0, boms[encoding].length) === 0) {
               // Skip BOM
-              buf = buf.slice(boms[encoding].length); // Renormalize original options with the new encoding
+              var bomLength = boms[encoding].length;
+              this.state.bufBytesStart += bomLength;
+              buf = buf.slice(bomLength); // Renormalize original options with the new encoding
 
               this.__normalizeOptions(_objectSpread(_objectSpread({}, this.__originalOptions), {}, {
                 encoding: encoding
@@ -882,9 +886,12 @@ var Parser = /*#__PURE__*/function (_Transform) {
                   continue;
                 }
 
+                this.state.bufBytesPos = this.state.bufBytesStart + pos;
+
                 var errField = this.__onField();
 
                 if (errField !== undefined) return errField;
+                this.state.bufBytesPos = this.state.bufBytesStart + pos + recordDelimiterLength;
 
                 var errRecord = this.__onRecord();
 
@@ -916,6 +923,8 @@ var Parser = /*#__PURE__*/function (_Transform) {
             var delimiterLength = this.__isDelimiter(buf, pos, chr);
 
             if (delimiterLength !== 0) {
+              this.state.bufBytesPos = this.state.bufBytesStart + pos;
+
               var _errField = this.__onField();
 
               if (_errField !== undefined) return _errField;
@@ -955,6 +964,8 @@ var Parser = /*#__PURE__*/function (_Transform) {
         } else {
           // Skip last line if it has no characters
           if (this.state.wasQuoting === true || this.state.record.length !== 0 || this.state.field.length !== 0) {
+            this.state.bufBytesPos = pos;
+
             var _errField2 = this.__onField();
 
             if (_errField2 !== undefined) return _errField2;
@@ -969,6 +980,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
           }
         }
       } else {
+        this.state.bufBytesStart += pos;
         this.state.previousBuf = buf.slice(pos);
       }
 
@@ -1461,6 +1473,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
     value: function __infoRecord() {
       var columns = this.options.columns;
       return _objectSpread(_objectSpread({}, this.__infoDataSet()), {}, {
+        bytes: this.state.bufBytesStart + this.state.bufBytesPos,
         error: this.state.error,
         header: columns === true,
         index: this.state.record.length
@@ -4049,31 +4062,52 @@ function unwrapListeners(arr) {
 
 function once(emitter, name) {
   return new Promise(function (resolve, reject) {
-    function eventListener() {
-      if (errorListener !== undefined) {
+    function errorListener(err) {
+      emitter.removeListener(name, resolver);
+      reject(err);
+    }
+
+    function resolver() {
+      if (typeof emitter.removeListener === 'function') {
         emitter.removeListener('error', errorListener);
       }
       resolve([].slice.call(arguments));
     };
-    var errorListener;
 
-    // Adding an error listener is not optional because
-    // if an error is thrown on an event emitter we cannot
-    // guarantee that the actual event we are waiting will
-    // be fired. The result could be a silent way to create
-    // memory or file descriptor leaks, which is something
-    // we should avoid.
+    eventTargetAgnosticAddListener(emitter, name, resolver, { once: true });
     if (name !== 'error') {
-      errorListener = function errorListener(err) {
-        emitter.removeListener(name, eventListener);
-        reject(err);
-      };
-
-      emitter.once('error', errorListener);
+      addErrorHandlerIfEventEmitter(emitter, errorListener, { once: true });
     }
-
-    emitter.once(name, eventListener);
   });
+}
+
+function addErrorHandlerIfEventEmitter(emitter, handler, flags) {
+  if (typeof emitter.on === 'function') {
+    eventTargetAgnosticAddListener(emitter, 'error', handler, flags);
+  }
+}
+
+function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
+  if (typeof emitter.on === 'function') {
+    if (flags.once) {
+      emitter.once(name, listener);
+    } else {
+      emitter.on(name, listener);
+    }
+  } else if (typeof emitter.addEventListener === 'function') {
+    // EventTarget does not have `error` event semantics like Node
+    // EventEmitters, we do not listen for `error` events here.
+    emitter.addEventListener(name, function wrapListener(arg) {
+      // IE does not have builtin `{ once: true }` support so we
+      // have to do it manually.
+      if (flags.once) {
+        emitter.removeEventListener(name, wrapListener);
+      }
+      listener(arg);
+    });
+  } else {
+    throw new TypeError('The "emitter" argument must be of type EventEmitter. Received type ' + typeof emitter);
+  }
 }
 
 },{}],8:[function(require,module,exports){

--- a/lib/es5/index.js
+++ b/lib/es5/index.js
@@ -12,7 +12,7 @@ function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArra
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
@@ -22,13 +22,13 @@ function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread n
 
 function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
-function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
@@ -50,7 +50,7 @@ function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) ===
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {})); return true; } catch (e) { return false; } }
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
@@ -504,6 +504,8 @@ var Parser = /*#__PURE__*/function (_Transform) {
       this.options = options;
       this.state = {
         bomSkipped: false,
+        bufBytesPos: 0,
+        bufBytesStart: 0,
         castField: fnCastField,
         commenting: false,
         // Current error encountered by a record
@@ -619,7 +621,9 @@ var Parser = /*#__PURE__*/function (_Transform) {
           for (var encoding in boms) {
             if (boms[encoding].compare(buf, 0, boms[encoding].length) === 0) {
               // Skip BOM
-              buf = buf.slice(boms[encoding].length); // Renormalize original options with the new encoding
+              var bomLength = boms[encoding].length;
+              this.state.bufBytesStart += bomLength;
+              buf = buf.slice(bomLength); // Renormalize original options with the new encoding
 
               this.__normalizeOptions(_objectSpread(_objectSpread({}, this.__originalOptions), {}, {
                 encoding: encoding
@@ -774,9 +778,12 @@ var Parser = /*#__PURE__*/function (_Transform) {
                   continue;
                 }
 
+                this.state.bufBytesPos = this.state.bufBytesStart + pos;
+
                 var errField = this.__onField();
 
                 if (errField !== undefined) return errField;
+                this.state.bufBytesPos = this.state.bufBytesStart + pos + recordDelimiterLength;
 
                 var errRecord = this.__onRecord();
 
@@ -808,6 +815,8 @@ var Parser = /*#__PURE__*/function (_Transform) {
             var delimiterLength = this.__isDelimiter(buf, pos, chr);
 
             if (delimiterLength !== 0) {
+              this.state.bufBytesPos = this.state.bufBytesStart + pos;
+
               var _errField = this.__onField();
 
               if (_errField !== undefined) return _errField;
@@ -847,6 +856,8 @@ var Parser = /*#__PURE__*/function (_Transform) {
         } else {
           // Skip last line if it has no characters
           if (this.state.wasQuoting === true || this.state.record.length !== 0 || this.state.field.length !== 0) {
+            this.state.bufBytesPos = pos;
+
             var _errField2 = this.__onField();
 
             if (_errField2 !== undefined) return _errField2;
@@ -861,6 +872,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
           }
         }
       } else {
+        this.state.bufBytesStart += pos;
         this.state.previousBuf = buf.slice(pos);
       }
 
@@ -1353,6 +1365,7 @@ var Parser = /*#__PURE__*/function (_Transform) {
     value: function __infoRecord() {
       var columns = this.options.columns;
       return _objectSpread(_objectSpread({}, this.__infoDataSet()), {}, {
+        bytes: this.state.bufBytesStart + this.state.bufBytesPos,
         error: this.state.error,
         header: columns === true,
         index: this.state.record.length

--- a/lib/index.js
+++ b/lib/index.js
@@ -431,6 +431,8 @@ class Parser extends Transform {
     this.options = options
     this.state = {
       bomSkipped: false,
+      bufBytesPos: 0,
+      bufBytesStart: 0,
       castField: fnCastField,
       commenting: false,
       // Current error encountered by a record
@@ -517,7 +519,9 @@ class Parser extends Transform {
         for(let encoding in boms){
           if(boms[encoding].compare(buf, 0, boms[encoding].length) === 0){
             // Skip BOM
-            buf = buf.slice(boms[encoding].length)
+            let bomLength = boms[encoding].length
+            this.state.bufBytesStart += bomLength
+            buf = buf.slice(bomLength)
             // Renormalize original options with the new encoding
             this.__normalizeOptions({...this.__originalOptions, encoding: encoding})
             break
@@ -657,8 +661,10 @@ class Parser extends Transform {
                 pos += recordDelimiterLength - 1
                 continue
               }
+              this.state.bufBytesPos = this.state.bufBytesStart + pos;
               const errField = this.__onField()
               if(errField !== undefined) return errField
+              this.state.bufBytesPos = this.state.bufBytesStart + pos + recordDelimiterLength;
               const errRecord = this.__onRecord()
               if(errRecord !== undefined) return errRecord
               if(to !== -1 && this.info.records >= to){
@@ -681,6 +687,7 @@ class Parser extends Transform {
           }
           let delimiterLength = this.__isDelimiter(buf, pos, chr)
           if(delimiterLength !== 0){
+            this.state.bufBytesPos = this.state.bufBytesStart + pos;
             const errField = this.__onField()
             if(errField !== undefined) return errField
             pos += delimiterLength - 1
@@ -730,6 +737,7 @@ class Parser extends Transform {
       }else{
         // Skip last line if it has no characters
         if(this.state.wasQuoting === true || this.state.record.length !== 0 || this.state.field.length !== 0){
+          this.state.bufBytesPos = pos;
           const errField = this.__onField()
           if(errField !== undefined) return errField
           const errRecord = this.__onRecord()
@@ -741,6 +749,7 @@ class Parser extends Transform {
         }
       }
     }else{
+      this.state.bufBytesStart += pos
       this.state.previousBuf = buf.slice(pos)
     }
     if(this.state.wasRowDelimiter === true){
@@ -1119,6 +1128,7 @@ class Parser extends Transform {
     const {columns} = this.options
     return {
       ...this.__infoDataSet(),
+      bytes: this.state.bufBytesStart + this.state.bufBytesPos,
       error: this.state.error,
       header: columns === true,
       index: this.state.record.length,

--- a/test/option.cast.coffee
+++ b/test/option.cast.coffee
@@ -65,6 +65,7 @@ describe 'Option `cast`', ->
       , (err, records) ->
         records.should.eql [
           [[
+            'bytes',
             'column', 'columns', 'comment_lines', 'empty_lines', 'error',
             'header', 'index', 'invalid_field_length', 'lines', 'quoting',
             'records'
@@ -84,11 +85,13 @@ describe 'Option `cast`', ->
       , (err, records) ->
         records.should.eql [
           [ '2000-01-01T05:00:00.000Z', {
+            bytes: 16,
             column: 1, columns: false, comment_lines: 0, empty_lines: 0, error: undefined,
             header: false, index: 1, invalid_field_length: 0, lines: 1,
             quoting: false, records: 0
           } ]
           [ '2050-11-27T05:00:00.000Z', {
+            bytes: 33,
             column: 1, columns: false, comment_lines: 0, empty_lines: 0, error: undefined,
             header: false, index: 1, invalid_field_length: 0, lines: 2,
             quoting: false, records: 1

--- a/test/option.info.coffee
+++ b/test/option.info.coffee
@@ -29,23 +29,38 @@ describe 'Option `info`', ->
       ''', info: true, (err, records) ->
         {info} = records[0]
         Object.keys(info).sort().should.eql [
+          'bytes',
           'columns', 'comment_lines', 'empty_lines', 'error', 'header',
           'index', 'invalid_field_length', 'lines', 'records'
         ]
         next err
           
-    it 'validate the `lines` property', (next) ->
+    it 'validate the `lines` and `bytes` properties', (next) ->
+      console.log(">" + '''
+      a,b,c
+      d,e,f
+      g,h,i
+      ''' + "<")
       parse '''
       a,b,c
       d,e,f
       g,h,i
       ''', info: true, (err, records) ->
         records.map(
-          ({info}) -> info.lines
-        ).should.eql [1, 2, 3] unless err
+          ({info}) -> [info.lines, info.bytes]
+        ).should.eql [[1, 6], [2, 12], [3, 17]] unless err
         next err
           
     it 'with skip_empty_lines', (next) ->
+      console.log(">" + '''
+      
+      a,b,c
+      
+      d,e,f
+      
+      g,h,i
+      ''' + "<")
+
       parse '''
       
       a,b,c
@@ -55,11 +70,19 @@ describe 'Option `info`', ->
       g,h,i
       ''', info: true, skip_empty_lines: true, (err, records) ->
         records.map(
-          ({info}) -> info.lines
-        ).should.eql [2, 4, 6] unless err
+          ({info}) -> [info.lines, info.bytes]
+        ).should.eql [[2, 7], [4, 14], [6, 20]] unless err
         next err
           
     it 'with comment', (next) ->
+      console.log(">" + '''
+      # line 1
+      a,b,c
+      # line 2
+      d,e,f
+      # line 3
+      g,h,i
+      ''' + "<")
       parse '''
       # line 1
       a,b,c
@@ -69,8 +92,8 @@ describe 'Option `info`', ->
       g,h,i
       ''', info: true, comment: '#', (err, records) ->
         records.map(
-          ({info}) -> info.lines
-        ).should.eql [2, 4, 6] unless err
+          ({info}) -> [info.lines, info.bytes]
+        ).should.eql [[2, 15], [4, 30], [6, 44]] unless err
         next err
           
     it 'with multiline records', (next) ->
@@ -81,7 +104,7 @@ describe 'Option `info`', ->
       g,h,i
       ''', info: true, (err, records) ->
         records.map(
-          ({info}) -> info.lines
-        ).should.eql [1, 3, 4] unless err
+          ({info}) -> [info.lines, info.bytes]
+        ).should.eql [[1, 6], [3, 15], [4, 20]] unless err
         next err
     

--- a/test/option.on_record.coffee
+++ b/test/option.on_record.coffee
@@ -61,6 +61,7 @@ describe 'Option `on_record`', ->
         skip_lines_with_error: true
       , (err, records) ->
         records.should.eql [[
+          'bytes',
           'columns', 'comment_lines', 'empty_lines', 'error', 'header',
           'index', 'invalid_field_length', 'lines', 'records'
         ]]
@@ -73,9 +74,11 @@ describe 'Option `on_record`', ->
         skip_lines_with_error: true
       , (err, records) ->
         records.should.eql [
+          bytes: 4,
           columns: false, comment_lines: 0, empty_lines: 0, error: undefined, header: false
           index: 2, invalid_field_length: 0, lines: 1, records: 1
         ,
+          bytes: 7,
           columns: false, comment_lines: 0, empty_lines: 0, error: undefined, header: false
           index: 2, invalid_field_length: 0, lines: 2, records: 2
         ]


### PR DESCRIPTION
I have a project where I'm planning to use node-csv-parse to read a large CSV file from Amazon S3 and then process the parsed records. The whole process may take hours, and if it fails in the middle I would like to be able to restart the job from the last record successfully processed. To that end, it would be handy to have the byte offset of each record in the stream as it is parsed so that I know where to start reading from if I need to restart the job.

This PR adds a `bytes` property to the `info` property that is produced when the `info` option is used that gives the byte offset in the stream of the end of the record (or, for fields, the end of the field). My implementation isn't great; if you think this is a feature worth having I would be happy for suggestions on how to improve it.