### PR TITLE
Create browser sync.d.ts

### DIFF
--- a/lib/browser/sync.d.ts
+++ b/lib/browser/sync.d.ts
@@ -1,0 +1,6 @@
+import * as csvParse from '../index';
+
+export = parse;
+
+declare function parse(input: string, options?: csvParse.Options): any;
+declare namespace parse {}


### PR DESCRIPTION
Importing `import parse from 'csv-parse/lib/browser/sync'` fails with typescript. 
This adds the same types as sync.d.ts